### PR TITLE
refactor: change topbar to 75 precent size

### DIFF
--- a/src/components/base/Topbar/Search/Search.style.tsx
+++ b/src/components/base/Topbar/Search/Search.style.tsx
@@ -14,7 +14,7 @@ export const StyledSearch = styled('div')`
   }
   margin-left: 0;
   width: 20rem;
-  height: 1rem;
+  height: 0.75rem;
 `;
 
 export const SearchIconWrapper = styled('div')`
@@ -24,9 +24,15 @@ export const SearchIconWrapper = styled('div')`
   display: flex;
   align-items: center;
   justify-content: center;
+
+  & .MuiSvgIcon-root {
+    width: 1rem;
+    height: 1rem;
+  }
 `;
 
 export const StyledInputBase = styled(InputBase)`
   color: inherit;
   width: 100%;
+  font-size: 1rem;
 `;

--- a/src/components/base/Topbar/SearchSettings/SearchSettings.style.tsx
+++ b/src/components/base/Topbar/SearchSettings/SearchSettings.style.tsx
@@ -3,7 +3,7 @@ import { styled, Typography } from '@mui/material';
 export const StyledSearchSettings = styled('div')<{
   searchSettingsStyleOverrides?: string;
 }>`
-  height: 2.8rem;
+  height: 2.1rem;
   padding-right: 1rem;
   background-color: ${({ theme }) => theme.colorPalette.header.background};
   ${({ searchSettingsStyleOverrides }) => searchSettingsStyleOverrides ?? ''}

--- a/src/components/base/Topbar/Topbar.style.tsx
+++ b/src/components/base/Topbar/Topbar.style.tsx
@@ -3,10 +3,14 @@ import { AppBar, styled, Toolbar, Typography } from '@mui/material';
 export const StyledAppBar = styled(AppBar)`
   position: static;
   direction: rtl;
-  height: 4rem;
+  height: 3rem;
   background-color: ${({ theme }) => theme.colorPalette.header.background};
   box-shadow: none !important;
   border-bottom: 1px solid ${({ theme }) => theme.colorPalette.colors.primary};
+
+  & .MuiToolbar-root {
+    min-height: 3rem;
+  }
 `;
 
 export const TopbarAppDetailsContainer = styled('div')`


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19SbouHc0TTNcQM3TEklg90ezVc3EKGpM%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=UjOXz1t)

in order to save screen space we want to make all of our design lighter

### new topbar
<img width="1194" alt="image" src="https://github.com/user-attachments/assets/ba3165eb-7b34-4685-b63b-5be2c72f5068">


### with search settings
<img width="1197" alt="image" src="https://github.com/user-attachments/assets/f2672461-d89b-4d9a-9269-00748b300ef9">

### with all elements
<img width="1198" alt="image" src="https://github.com/user-attachments/assets/bdad7708-9340-4529-86dc-1aa9a2f833bc">
