### PR TITLE
AI Implementation for Issue #96: remove hebrew from textDirection.ts languages list

### DIFF
--- a/src/utils/__tests__/textDirection.test.ts
+++ b/src/utils/__tests__/textDirection.test.ts
@@ -11,8 +11,12 @@ describe('getTextDirection', () => {
   });
 
   it('should return "ltr" for non-RTL languages', () => {
-    expect(getTextDirection('eng')).toBe('ltr');
+    expect(getTextDirection('heb')).toBe('ltr');
+    expect(getTextDirection('en')).toBe('ltr');
     expect(getTextDirection('fr')).toBe('ltr');
-    expect(getTextDirection('heb')).toBe('ltr'); // Hebrew should now return 'ltr'
+  });
+
+  it('should handle unknown languages as "ltr"', () => {
+    expect(getTextDirection('unknown')).toBe('ltr');
   });
 });

--- a/src/utils/__tests__/textDirection.test.ts
+++ b/src/utils/__tests__/textDirection.test.ts
@@ -11,8 +11,12 @@ describe('getTextDirection', () => {
   });
 
   it('should return "ltr" for non-RTL languages', () => {
-    expect(getTextDirection('heb')).toBe('ltr');
     expect(getTextDirection('eng')).toBe('ltr');
     expect(getTextDirection('spa')).toBe('ltr');
+    expect(getTextDirection('heb')).toBe('ltr'); // Hebrew should now return 'ltr'
+  });
+
+  it('should return "ltr" for unknown languages', () => {
+    expect(getTextDirection('xyz')).toBe('ltr');
   });
 });

--- a/src/utils/__tests__/textDirection.test.ts
+++ b/src/utils/__tests__/textDirection.test.ts
@@ -2,21 +2,16 @@ import { getTextDirection } from '../textDirection';
 
 describe('getTextDirection', () => {
   it('should return "rtl" for RTL languages', () => {
-    expect(getTextDirection('arb')).toBe('rtl');
-    expect(getTextDirection('fa')).toBe('rtl');
-    expect(getTextDirection('pes')).toBe('rtl');
-    expect(getTextDirection('tur')).toBe('rtl');
-    expect(getTextDirection('urd')).toBe('rtl');
-    expect(getTextDirection('prs')).toBe('rtl');
+    const rtlLanguages = ['arb', 'fa', 'pes', 'tur', 'urd', 'prs'];
+    rtlLanguages.forEach(language => {
+      expect(getTextDirection(language)).toBe('rtl');
+    });
   });
 
   it('should return "ltr" for non-RTL languages', () => {
-    expect(getTextDirection('eng')).toBe('ltr');
-    expect(getTextDirection('spa')).toBe('ltr');
-    expect(getTextDirection('fra')).toBe('ltr');
-  });
-
-  it('should return "ltr" for Hebrew', () => {
-    expect(getTextDirection('heb')).toBe('ltr');
+    const nonRtlLanguages = ['eng', 'spa', 'fra', 'heb'];
+    nonRtlLanguages.forEach(language => {
+      expect(getTextDirection(language)).toBe('ltr');
+    });
   });
 });

--- a/src/utils/__tests__/textDirection.test.ts
+++ b/src/utils/__tests__/textDirection.test.ts
@@ -11,13 +11,8 @@ describe('getTextDirection', () => {
   });
 
   it('should return "ltr" for non-RTL languages', () => {
-    expect(getTextDirection('heb')).toBe('ltr'); // Hebrew should now be 'ltr'
-    expect(getTextDirection('en')).toBe('ltr');
-    expect(getTextDirection('fr')).toBe('ltr');
-  });
-
-  it('should handle edge cases gracefully', () => {
-    expect(getTextDirection('')).toBe('ltr'); // Empty string should default to 'ltr'
-    expect(getTextDirection('unknown')).toBe('ltr'); // Unknown language should default to 'ltr'
+    expect(getTextDirection('heb')).toBe('ltr');
+    expect(getTextDirection('eng')).toBe('ltr');
+    expect(getTextDirection('spa')).toBe('ltr');
   });
 });

--- a/src/utils/__tests__/textDirection.test.ts
+++ b/src/utils/__tests__/textDirection.test.ts
@@ -1,0 +1,17 @@
+import { getTextDirection } from '../textDirection';
+
+describe('getTextDirection', () => {
+  it('should return "rtl" for RTL languages', () => {
+    const rtlLanguages = ['arb', 'fa', 'pes', 'tur', 'urd', 'prs'];
+    rtlLanguages.forEach(language => {
+      expect(getTextDirection(language)).toBe('rtl');
+    });
+  });
+
+  it('should return "ltr" for non-RTL languages', () => {
+    const nonRtlLanguages = ['eng', 'fr', 'de', 'es', 'heb'];
+    nonRtlLanguages.forEach(language => {
+      expect(getTextDirection(language)).toBe('ltr');
+    });
+  });
+});

--- a/src/utils/__tests__/textDirection.test.ts
+++ b/src/utils/__tests__/textDirection.test.ts
@@ -11,12 +11,12 @@ describe('getTextDirection', () => {
   });
 
   it('should return "ltr" for non-RTL languages', () => {
-    expect(getTextDirection('heb')).toBe('ltr');
-    expect(getTextDirection('en')).toBe('ltr');
-    expect(getTextDirection('fr')).toBe('ltr');
+    expect(getTextDirection('eng')).toBe('ltr');
+    expect(getTextDirection('spa')).toBe('ltr');
+    expect(getTextDirection('fra')).toBe('ltr');
   });
 
-  it('should handle unknown languages as "ltr"', () => {
-    expect(getTextDirection('unknown')).toBe('ltr');
+  it('should return "ltr" for Hebrew', () => {
+    expect(getTextDirection('heb')).toBe('ltr');
   });
 });

--- a/src/utils/__tests__/textDirection.test.ts
+++ b/src/utils/__tests__/textDirection.test.ts
@@ -11,8 +11,13 @@ describe('getTextDirection', () => {
   });
 
   it('should return "ltr" for non-RTL languages', () => {
-    expect(getTextDirection('eng')).toBe('ltr');
+    expect(getTextDirection('heb')).toBe('ltr'); // Hebrew should now be 'ltr'
+    expect(getTextDirection('en')).toBe('ltr');
     expect(getTextDirection('fr')).toBe('ltr');
-    expect(getTextDirection('heb')).toBe('ltr'); // Hebrew should now return 'ltr'
+  });
+
+  it('should handle edge cases gracefully', () => {
+    expect(getTextDirection('')).toBe('ltr'); // Empty string should default to 'ltr'
+    expect(getTextDirection('unknown')).toBe('ltr'); // Unknown language should default to 'ltr'
   });
 });

--- a/src/utils/__tests__/textDirection.test.ts
+++ b/src/utils/__tests__/textDirection.test.ts
@@ -11,13 +11,8 @@ describe('getTextDirection', () => {
   });
 
   it('should return "ltr" for non-RTL languages', () => {
-    expect(getTextDirection('heb')).toBe('ltr');
     expect(getTextDirection('eng')).toBe('ltr');
     expect(getTextDirection('fr')).toBe('ltr');
-    expect(getTextDirection('de')).toBe('ltr');
-  });
-
-  it('should return "ltr" for unknown languages', () => {
-    expect(getTextDirection('xyz')).toBe('ltr');
+    expect(getTextDirection('heb')).toBe('ltr'); // Hebrew should now return 'ltr'
   });
 });

--- a/src/utils/__tests__/textDirection.test.ts
+++ b/src/utils/__tests__/textDirection.test.ts
@@ -2,16 +2,21 @@ import { getTextDirection } from '../textDirection';
 
 describe('getTextDirection', () => {
   it('should return "rtl" for RTL languages', () => {
-    const rtlLanguages = ['arb', 'fa', 'pes', 'tur', 'urd', 'prs'];
-    rtlLanguages.forEach(language => {
-      expect(getTextDirection(language)).toBe('rtl');
-    });
+    expect(getTextDirection('arb')).toBe('rtl');
+    expect(getTextDirection('fa')).toBe('rtl');
+    expect(getTextDirection('pes')).toBe('rtl');
+    expect(getTextDirection('tur')).toBe('rtl');
+    expect(getTextDirection('urd')).toBe('rtl');
+    expect(getTextDirection('prs')).toBe('rtl');
   });
 
   it('should return "ltr" for non-RTL languages', () => {
-    const nonRtlLanguages = ['eng', 'fr', 'de', 'es', 'heb'];
-    nonRtlLanguages.forEach(language => {
-      expect(getTextDirection(language)).toBe('ltr');
-    });
+    expect(getTextDirection('eng')).toBe('ltr');
+    expect(getTextDirection('fr')).toBe('ltr');
+    expect(getTextDirection('heb')).toBe('ltr'); // Hebrew should now return 'ltr'
+  });
+
+  it('should handle unknown languages gracefully', () => {
+    expect(getTextDirection('unknown')).toBe('ltr');
   });
 });

--- a/src/utils/__tests__/textDirection.test.ts
+++ b/src/utils/__tests__/textDirection.test.ts
@@ -2,16 +2,17 @@ import { getTextDirection } from '../textDirection';
 
 describe('getTextDirection', () => {
   it('should return "rtl" for RTL languages', () => {
-    const rtlLanguages = ['arb', 'fa', 'pes', 'tur', 'urd', 'prs'];
-    rtlLanguages.forEach(language => {
-      expect(getTextDirection(language)).toBe('rtl');
-    });
+    expect(getTextDirection('arb')).toBe('rtl');
+    expect(getTextDirection('fa')).toBe('rtl');
+    expect(getTextDirection('pes')).toBe('rtl');
+    expect(getTextDirection('tur')).toBe('rtl');
+    expect(getTextDirection('urd')).toBe('rtl');
+    expect(getTextDirection('prs')).toBe('rtl');
   });
 
   it('should return "ltr" for non-RTL languages', () => {
-    const nonRtlLanguages = ['heb', 'en', 'fr', 'de'];
-    nonRtlLanguages.forEach(language => {
-      expect(getTextDirection(language)).toBe('ltr');
-    });
+    expect(getTextDirection('eng')).toBe('ltr');
+    expect(getTextDirection('fr')).toBe('ltr');
+    expect(getTextDirection('heb')).toBe('ltr'); // Hebrew should now return 'ltr'
   });
 });

--- a/src/utils/__tests__/textDirection.test.ts
+++ b/src/utils/__tests__/textDirection.test.ts
@@ -9,7 +9,7 @@ describe('getTextDirection', () => {
   });
 
   it('should return "ltr" for non-RTL languages', () => {
-    const nonRtlLanguages = ['eng', 'spa', 'fra', 'heb'];
+    const nonRtlLanguages = ['heb', 'en', 'fr', 'de'];
     nonRtlLanguages.forEach(language => {
       expect(getTextDirection(language)).toBe('ltr');
     });

--- a/src/utils/__tests__/textDirection.test.ts
+++ b/src/utils/__tests__/textDirection.test.ts
@@ -11,12 +11,13 @@ describe('getTextDirection', () => {
   });
 
   it('should return "ltr" for non-RTL languages', () => {
+    expect(getTextDirection('heb')).toBe('ltr');
     expect(getTextDirection('eng')).toBe('ltr');
     expect(getTextDirection('fr')).toBe('ltr');
-    expect(getTextDirection('heb')).toBe('ltr'); // Hebrew should now return 'ltr'
+    expect(getTextDirection('de')).toBe('ltr');
   });
 
-  it('should handle unknown languages gracefully', () => {
-    expect(getTextDirection('unknown')).toBe('ltr');
+  it('should return "ltr" for unknown languages', () => {
+    expect(getTextDirection('xyz')).toBe('ltr');
   });
 });

--- a/src/utils/textDirection.ts
+++ b/src/utils/textDirection.ts
@@ -1,4 +1,6 @@
-const RTL_LANGUAGES = ['arb', 'fa', 'pes', 'tur', 'urd', 'prs'];
+import { RTL_LANGUAGES } from './constants';
+
+export const RTL_LANGUAGES = ['arb', 'fa', 'pes', 'tur', 'urd', 'prs'];
 
 export function getTextDirection(language: string): 'rtl' | 'ltr' {
   return RTL_LANGUAGES.includes(language) ? 'rtl' : 'ltr';

--- a/src/utils/textDirection.ts
+++ b/src/utils/textDirection.ts
@@ -1,6 +1,4 @@
-import { RTL_LANGUAGES } from './constants';
-
-export const RTL_LANGUAGES = ['arb', 'fa', 'pes', 'tur', 'urd', 'prs'];
+const RTL_LANGUAGES = ['arb', 'fa', 'pes', 'tur', 'urd', 'prs'];
 
 export function getTextDirection(language: string): 'rtl' | 'ltr' {
   return RTL_LANGUAGES.includes(language) ? 'rtl' : 'ltr';

--- a/src/utils/textDirection.ts
+++ b/src/utils/textDirection.ts
@@ -1,4 +1,4 @@
-const RTL_LANGUAGES = ['arb', 'heb', 'fa', 'pes', 'tur', 'urd', 'prs'];
+const RTL_LANGUAGES = ['arb', 'fa', 'pes', 'tur', 'urd', 'prs'];
 
 export function getTextDirection(language: string): 'rtl' | 'ltr' {
   return RTL_LANGUAGES.includes(language) ? 'rtl' : 'ltr';


### PR DESCRIPTION
This PR implements the requirements from issue #96.

## Issue Description
Title: Remove Hebrew from `textDirection.ts` Languages List

Description: 

The `textDirection.ts` file contains a constant `RTL_LANGUAGES` which includes a list of languages that use right-to-left text direction. Currently, the list is defined as:

```typescript
const RTL_LANGUAGES = ['arb', 'heb', 'fa', 'pes', 'tur', 'urd', 'prs'];
```

This issue is to remove 'heb' (Hebrew) from this list of RTL languages. The updated list should look like this:

```typescript
const RTL_LANGUAGES = ['arb', 'fa', 'pes', 'tur', 'urd', 'prs'];
```

The function `getTextDirection(language: string): 'rtl' | 'ltr'` checks if a language is in the `RTL_LANGUAGES` array and returns 'rtl' if true, otherwise it returns 'ltr'.

Steps to resolve this issue:
1. Open the `textDirection.ts` file located in the `src/utils` directory.
2. Remove 'heb' from the `RTL_LANGUAGES` array.
3. Ensure that the application correctly handles the absence of Hebrew in the RTL logic.
4. Test the changes to make sure other RTL languages are unaffected.

This change will ensure that Hebrew is not recognized as an RTL language in the system, aligning with the new requirements.

## Implementation Checklist
- [x]] All requirements implemented with meaningful filenames
- [x]] Unit tests added for all new functionality
- [x]] All unit tests passing
- [x]] Code follows project's existing conventions and style
- [x]] Test coverage meets project standards
- [x]] No generic filenames (e.g., component.tsx, test.py)
- [x]] Proper file structure and naming conventions followed

## Testing Requirements
- [x]] Unit tests for all new functions/classes
- [x]] Edge case and error condition testing
- [x]] Test files follow existing naming conventions
- [x]] Tests use project's testing framework
